### PR TITLE
Remove legacy regular() behavior

### DIFF
--- a/docs/api-reference/v1/introduction.mdx
+++ b/docs/api-reference/v1/introduction.mdx
@@ -1,28 +1,20 @@
 ---
-title: "API Introduction"
-description: "Welcome to the Dots API Reference v1"
+title: 'API Introduction'
+description: 'Welcome to the Dots API Reference v1'
 ---
 
 <Card
   title="Download OpenAPI specification"
   href="https://docs.dots.dev/redocusaurus/plugin-redoc-0.yaml"
-  icon={regular("file-arrow-down")}
+  icon="file-arrow-down"
 >
   Click to Download
 </Card>
 
-<Card
-  title="Contact Us"
-  icon={regular("envelope")}
-  href="mailto:kartikye@senddots.com"
->
+<Card title="Contact Us" icon="envelope" href="mailto:kartikye@senddots.com">
   E-mail kartikye@senddots.com for Dots end point descriptions
 </Card>
 
-<Card
-  title="Find out more about Dots"
-  icon={regular("book-open-cover")}
-  href="/"
->
+<Card title="Find out more about Dots" icon="book-open-cover" href="/">
   Return to the main page
 </Card>

--- a/docs/api-reference/v2/introduction.mdx
+++ b/docs/api-reference/v2/introduction.mdx
@@ -1,28 +1,20 @@
 ---
-title: "API Introduction"
-description: "Welcome to the Dots API Reference"
+title: 'API Introduction'
+description: 'Welcome to the Dots API Reference'
 ---
 
 <Card
   title="Download OpenAPI specification"
   href="https://docs.dots.dev/redocusaurus/plugin-redoc-0.yaml"
-  icon={regular("file-arrow-down")}
+  icon="file-arrow-down"
 >
   Click to Download
 </Card>
 
-<Card
-  title="Contact Us"
-  icon={regular("envelope")}
-  href="mailto:kartikye@senddots.com"
->
+<Card title="Contact Us" icon="envelope" href="mailto:kartikye@senddots.com">
   E-mail kartikye@senddots.com for Dots end point descriptions
 </Card>
 
-<Card
-  title="Find out more about Dots"
-  icon={regular("book-open-cover")}
-  href="/"
->
+<Card title="Find out more about Dots" icon="book-open-cover" href="/">
   Return to the main page
 </Card>

--- a/docs/overview/environments.mdx
+++ b/docs/overview/environments.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Environments"
-description: "Dots provides two enviromenments: Production and Sandbox."
+title: 'Environments'
+description: 'Dots provides two enviromenments: Production and Sandbox.'
 ---
 
 The Sandbox environment lets you develop and test your integration without touching live funds.
@@ -17,18 +17,18 @@ The sandbox environment can be enabled on the Dots dashboard ([https://dashboard
 
 ### Payouts
 
-<Card title="ACH" icon={regular("money-bill-transfer")}>
+<Card title="ACH" icon="money-bill-transfer">
   Live bank accounts can be connected via Plaid but no transactions will go
   through. Please ensure that the Plaid interface is properly integrated into
   your application.
 </Card>
 
-<Card title="PayPal" icon={brands("paypal")}>
+<Card title="PayPal" icon="paypal">
   Any email can be connected to PayPal and all transactions return a successful
   response.
 </Card>
 
-<Card title="Venmo" icon={solid("money-bill-1-wave")}>
+<Card title="Venmo" icon="money-bill-1-wave" iconType="solid">
   Any phone number can be connected to Venmo and all transactions return a
   successful response.
 </Card>

--- a/docs/overview/introduction.mdx
+++ b/docs/overview/introduction.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Dots API V2 Documentation"
-sidebarTitle: "Introduction"
-description: "Welcome to Dots!"
+title: 'Dots API V2 Documentation'
+sidebarTitle: 'Introduction'
+description: 'Welcome to Dots!'
 ---
 
 <Warning>V1 User ids are not compatible with the V2 API</Warning>
@@ -14,11 +14,11 @@ In this documentation, you'll find everything you need to get started with Dots.
 
 All Dots endpoints are testable via our sandbox environment (see below).
 
-<Card title="Sandbox Endpoint" icon={regular("screwdriver-wrench")}>
+<Card title="Sandbox Endpoint" icon="screwdriver-wrench">
   pls.senddotssandbox.com/api
 </Card>
 
-<Card title="Production Endpoint" icon={regular("circle-play")}>
+<Card title="Production Endpoint" icon="circle-play">
   pls.dots.dev/api
 </Card>
 

--- a/docs/v1/api-reference/introduction.mdx
+++ b/docs/v1/api-reference/introduction.mdx
@@ -1,28 +1,20 @@
 ---
-title: "API Introduction"
-description: "Welcome to the Dots API Reference"
+title: 'API Introduction'
+description: 'Welcome to the Dots API Reference'
 ---
 
 <Card
   title="Download OpenAPI specification"
   href="https://docs.dots.dev/redocusaurus/plugin-redoc-0.yaml"
-  icon={regular("file-arrow-down")}
+  icon="file-arrow-down"
 >
   Click to Download
 </Card>
 
-<Card
-  title="Contact Us"
-  icon={regular("envelope")}
-  href="mailto:kartikye@senddots.com"
->
+<Card title="Contact Us" icon="envelope" href="mailto:kartikye@senddots.com">
   E-mail kartikye@senddots.com for Dots end point descriptions
 </Card>
 
-<Card
-  title="Find out more about Dots"
-  icon={regular("book-open-cover")}
-  href="/"
->
+<Card title="Find out more about Dots" icon="book-open-cover" href="/">
   Return to the main page
 </Card>

--- a/docs/v1/introduction.mdx
+++ b/docs/v1/introduction.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Dots API Documentation"
-sidebarTitle: "Introduction"
-description: "Welcome to Dots!"
+title: 'Dots API Documentation'
+sidebarTitle: 'Introduction'
+description: 'Welcome to Dots!'
 ---
 
 Our API aims to make moving money between businesses and people easy and modular. Whether you want to enable payouts to users via ACH or Venmo, build an embeddable wallet system into your application, or even just file 1099 forms, we've built an API to take all of the hassle away.
@@ -12,11 +12,11 @@ In this documentation, you'll find everything you need to get started with Dots.
 
 All Dots endpoints are testable via our sandbox environment (see below).
 
-<Card title="Sandbox Endpoint" icon={regular("screwdriver-wrench")}>
+<Card title="Sandbox Endpoint" icon="screwdriver-wrench">
   pls.senddotssandbox.com/api
 </Card>
 
-<Card title="Production Endpoint" icon={regular("circle-play")}>
+<Card title="Production Endpoint" icon="circle-play">
   pls.dots.dev/api
 </Card>
 

--- a/docs/v1/quick_start/environments.mdx
+++ b/docs/v1/quick_start/environments.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Environments"
-description: "Dots provides two enviromenments: Production and Sandbox."
+title: 'Environments'
+description: 'Dots provides two enviromenments: Production and Sandbox.'
 ---
 
 The Sandbox environment lets you develop and test your integration without touching live funds.
@@ -17,18 +17,18 @@ The sandbox lives on its own domain at [https://senddotssandbox.com](https://sen
 
 ### Payouts
 
-<Card title="ACH" icon={regular("money-bill-transfer")}>
+<Card title="ACH" icon="money-bill-transfer">
   Live bank accounts can be connected via Plaid but no transactions will go
   through. Please ensure that the Plaid interface is properly integrated into
   your application.
 </Card>
 
-<Card title="PayPal" icon={brands("paypal")}>
+<Card title="PayPal" icon="paypal">
   Any email can be connected to PayPal and all transactions will go through.
   Please be careful!
 </Card>
 
-<Card title="Testing" icon={regular("screwdriver-wrench")}>
+<Card title="Testing" icon="screwdriver-wrench">
   We recommend pointing all integration tests to the sandbox using developer
   keys.
 </Card>


### PR DESCRIPTION
Removes the use of `regular()` and `brand()` from the documentation as it has been deprecated