### PR TITLE
Make director SSN conditionally required

### DIFF
--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -3739,7 +3739,6 @@ components:
               - dob
               - ownership_percentage
               - address
-              - ssn
             properties:
               address:
                 type: object
@@ -3810,6 +3809,14 @@ components:
                 minLength: 3
                 type: string
                 description: Employee title or ownership role
+            if:
+              properties:
+                address:
+                  properties:
+                    country:
+                      const: US
+            then:
+              required: [ssn]
           type: array
         flow_of_funds:
           type: object


### PR DESCRIPTION
Forgot that this is only required for US directors. I doubt Mintlify displays this constraint in a meaningful way though.