### PR TITLE
Add pdf-form-fill step documentation

### DIFF
--- a/docs/flows/overview.mdx
+++ b/docs/flows/overview.mdx
@@ -62,6 +62,17 @@ The `redirect` step lets you redirect the user to a URL of your choice. The `red
 }
 ```
 
+### PDF Form Fill
+
+The `pdf-form-fill` step presents the user with a PDF form to fill out. You must provide a `template_id` to specify which PDF template to use:
+
+```json
+{
+  "name": "pdf-form-fill",
+  "template_id": "<template_id>"
+}
+```
+
 ## Example Flow
 
 This example flow onboards a user, collects compliance information, and then lets them manage their payment methods.

--- a/docs/guides/flow-payouts.mdx
+++ b/docs/guides/flow-payouts.mdx
@@ -40,6 +40,7 @@ Flow steps can be used individually or chained together. The following table pre
 | `manage-payments`  | Enable the user to connect a bank account for ACH payments.                             | <ul><li>`hide_continue_button` (boolean): Hides the continue button after the flow is completed.</li></ul> |
 | `payout`           | Allows the user to initiate a payout to their preferred payout method.                 | <ul><li>`payout_fee_party` (`platform`, `user`): Defines who pays the fee for the payout.</li></ul> |
 | `redirect`         | Redirects the user to a URL of your choice. | <ul><li>`redirect_url` (string): Defines the URL the user will be redirected to at the end of the Flow.</li><li>`hide_continue_button` (bollean): Hides the continue button after the flow is completed.</li></ul> |
+| `pdf-form-fill`    | Presents the user with a PDF form to fill out. | <ul><li>`template_id` (string): The ID of the PDF template to use.</li></ul> |
 
 
 <Note>

--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -881,6 +881,7 @@ paths:
                           - payout
                           - background-check
                           - redirect
+                          - pdf-form-fill
                         description: The `step` name.
                       - type: object
                         title: Step With Options
@@ -895,6 +896,7 @@ paths:
                               - payout
                               - background-check
                               - redirect
+                              - pdf-form-fill
                             description: The `step` name.
                           auto_payout_enabled:
                             type: boolean
@@ -905,6 +907,9 @@ paths:
                             pattern: 'https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)'
                             description: URL to redirect for the `redirect` step.
                             format: uri
+                          template_id:
+                            type: string
+                            description: The ID of the PDF template to use for the `pdf-form-fill` step.
                           hide_continue_button:
                             type: boolean
                             description: Hide the continue button on the flow UI. Defaults to `false`.
@@ -1098,6 +1103,7 @@ paths:
                       - manage-payouts
                       - payout
                       - redirect
+                      - pdf-form-fill
                 accounting_data:
                   type: object
                   properties:
@@ -1499,6 +1505,7 @@ paths:
                       - manage-payouts
                       - payout
                       - redirect
+                      - pdf-form-fill
                 tax_exempt:
                   type: boolean
                   description: Payouts marked as `tax_exempt` will not be counted towards the 1099 threshold.
@@ -4209,6 +4216,7 @@ components:
               - manage-payouts
               - payout
               - redirect
+              - pdf-form-fill
         completed_steps:
           type: array
           description: Array of steps that have been completed in the flow.
@@ -4222,6 +4230,7 @@ components:
               - manage-payouts
               - payout
               - redirect
+              - pdf-form-fill
         link:
           type: string
           format: uri


### PR DESCRIPTION
Documents the pdf-form-fill flow step in the overview and flow-payouts guide, and adds it to the v2 OpenAPI spec with template_id support.