### PR TITLE
document per-user payout_options_exclude_list on /v2/users

### DIFF
--- a/docs/users/create-a-user.mdx
+++ b/docs/users/create-a-user.mdx
@@ -76,6 +76,7 @@ Make a `POST` request to the [/v2/users](/apireference/v2/users/create-user) end
 | last_name    | string             | ✔️       | User's last name as a string                                                                                 |
 | username     | string             |          | User's username on your platform. If the username is taken or left blank a random username will be generated |
 | metadata     | string/object/null |          | Optional metadata to be stored with the user                                                                 |
+| payout_options_exclude_list | array |          | List of payout methods to hide from this user (e.g. `["venmo", "paypal"]`).                                  |
 
 ## Verifying the created User
 

--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -156,6 +156,12 @@ paths:
                     - string
                     - object
                   description: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+                payout_options_exclude_list:
+                  type: array
+                  uniqueItems: true
+                  items:
+                    $ref: "#/components/schemas/rail"
+                  description: List of payout rails to hide from this user in the Dots iframe and block on payout creation. Empty or omitted means no restriction.
               required:
                 - first_name
                 - last_name
@@ -256,6 +262,12 @@ paths:
                   description: Income paid outside of the Dots platform in 2024.
                 metadata:
                   description: Arbitrary metadata
+                payout_options_exclude_list:
+                  type: array
+                  uniqueItems: true
+                  items:
+                    $ref: "#/components/schemas/rail"
+                  description: Replace the user's payout exclude list. Pass [] to clear.
   "/v2/users/{user_id}/compliance":
     parameters:
       - schema:
@@ -4650,6 +4662,11 @@ components:
             - object
             - "null"
           description: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+        payout_options_exclude_list:
+          type: array
+          items:
+            $ref: "#/components/schemas/rail"
+          description: Payout rails hidden from this user. Stacks with app-level exclusions.
     wallet:
       type: object
       properties:


### PR DESCRIPTION
adds the field to the OpenAPI spec for POST and PATCH /v2/users and the user response schema so it shows up in the API reference.