### PR TITLE
Fix documentation audit issues across API and guides

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,1 @@
+mint.old.json

--- a/docs/apireference.mdx
+++ b/docs/apireference.mdx
@@ -1,0 +1,31 @@
+---
+title: "API Reference"
+description: "Browse Dots API endpoint groups, integration patterns, and response conventions."
+---
+
+Use the Dots API Reference to explore endpoint groups, request schemas, and example payloads generated from the OpenAPI spec.
+
+<Note>Create-style endpoints may return either `200 OK` or `201 Created`, depending on the route. Treat any documented `2xx` response as success in generated or hand-written clients.</Note>
+
+<CardGroup cols={2}>
+  <Card title="Users" icon="users" href="/apireference/users/create-a-user">
+    Create users, submit compliance information, verify phone numbers, and manage payout methods.
+  </Card>
+  <Card title="Flows" icon="circle-nodes" href="/apireference/flows/create-a-flow">
+    Create embeddable payout and onboarding flows, then retrieve their status.
+  </Card>
+  <Card title="Transfers" icon="arrows-left-right" href="/apireference/transfers/create-a-transfer">
+    Move funds between your App wallet and users with signed transfer amounts.
+  </Card>
+  <Card title="Payouts" icon="money-bill-transfer" href="/apireference/payouts/create-a-payout">
+    Issue payouts directly or send payout links for users to claim.
+  </Card>
+  <Card title="Refunds" icon="rotate-left" href="/apireference/refunds/create-a-refund">
+    Refund payment intents and attach structured metadata when needed.
+  </Card>
+  <Card title="References" icon="book" href="/references/users">
+    Read supporting documentation for webhooks, idempotency, metadata, and users.
+  </Card>
+</CardGroup>
+
+If you are integrating with an AI tool, use the [Documentation Index](/llms.txt) for a route-level summary or [llms-full.txt](/llms-full.txt) for a combined Markdown export of the docs.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "Dots",
+  "description": "Dots developer documentation for payouts, flows, users, compliance, and API integrations.",
   "colors": {
     "primary": "#F4BC24",
     "light": "#ffebac",
@@ -82,6 +83,20 @@
       ]
     }
   },
+  "redirects": [
+    {
+      "source": "/overview/dots-concepts",
+      "destination": "/overview/concepts"
+    },
+    {
+      "source": "/overview/api-authentication",
+      "destination": "/overview/authentication"
+    },
+    {
+      "source": "/overview/api-environments",
+      "destination": "/overview/environments"
+    }
+  ],
   "logo": {
     "light": "/logo/light.png",
     "dark": "/logo/dark.png"
@@ -106,6 +121,11 @@
     "color": {
       "light": "#FEFDFB",
       "dark": "#18181B"
+    }
+  },
+  "seo": {
+    "metatags": {
+      "canonical": "https://dotsdev.mintlify.app"
     }
   },
   "navbar": {

--- a/docs/guides/batch-payouts.mdx
+++ b/docs/guides/batch-payouts.mdx
@@ -42,6 +42,8 @@ Each batch contains a shared `metadata` object and a list of payout items. Every
 
 Use [`POST /v2/payout-batches`](/apireference/payout-batches/create-a-payout-batch) with your App credentials. Reuse the same `idempotency_key` to safely retry the request.
 
+<Note>Batch payout `amount` values are always payout amounts in cents. If you use the separate [Create a Transfer](/apireference/transfers/create-a-transfer) endpoint elsewhere in your workflow, remember that transfers use signed amounts: negative sends funds to the user and positive debits the user.</Note>
+
 <CodeGroup>
 ```sh Request
 curl --request POST \

--- a/docs/guides/batch-payouts.mdx
+++ b/docs/guides/batch-payouts.mdx
@@ -48,7 +48,7 @@ Use [`POST /v2/payout-batches`](/apireference/payout-batches/create-a-payout-bat
 ```sh Request
 curl --request POST \
   --url https://api.senddotssandbox.com/api/v2/payout-batches \
-  --header 'Authorization: Basic <client_id:api_key>' \
+  --header 'Authorization: Basic <base64(client_id:api_key)>' \
   --header 'Content-Type: application/json' \
   --data '{
     "idempotency_key": "a7bb54d2-7342-4d13-a8aa-9d999753128b",
@@ -61,7 +61,7 @@ curl --request POST \
         "user_id": "a169451c-8525-4352-b8ca-070dd449a1a5",
         "amount": 1000,
         "platform": "paypal",
-        "idempotency_key": "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8",
+        "idempotency_key": "c3d4e5f6-a7b8-49c0-b1d2-e3f4a5b6c7d8",
         "fund": true,
         "tax_exempt": false,
         "metadata": {
@@ -73,7 +73,7 @@ curl --request POST \
         "amount": 2500,
         "platform": "ach",
         "account_id": "c369451c-a725-6552-d0ec-272ff669c3c7",
-        "idempotency_key": "d4e5f6g7-h8i9-j0k1-l2m3-n4o5p6q7r8s9",
+        "idempotency_key": "d4e5f6a7-b8c9-40d1-a2e3-f4a5b6c7d8e9",
         "fund": true,
         "tax_exempt": false
       }
@@ -106,7 +106,7 @@ Poll [`GET /v2/payout-batches/{payout_batch_id}`](/apireference/payout-batches/r
 ```sh
 curl --request GET \
   --url https://api.senddotssandbox.com/api/v2/payout-batches/e5d5863a-498d-4551-a3dc-e31012503f23 \
-  --header 'Authorization: Basic <client_id:api_key>'
+  --header 'Authorization: Basic <base64(client_id:api_key)>'
 ```
 
 ### Retrieve per-item results
@@ -117,7 +117,7 @@ Call `GET /v2/payout-batches/{payout_batch_id}/results` for detailed outcomes. S
 ```sh Request
 curl --request GET \
   --url "https://api.senddotssandbox.com/api/v2/payout-batches/e5d5863a-498d-4551-a3dc-e31012503f23/results?include_request=true" \
-  --header 'Authorization: Basic <client_id:api_key>'
+  --header 'Authorization: Basic <base64(client_id:api_key)>'
 ```
 
 ```json Response
@@ -128,7 +128,7 @@ curl --request GET \
   "items": [
     {
       "user_id": "a169451c-8525-4352-b8ca-070dd449a1a5",
-      "idempotency_key": "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8",
+      "idempotency_key": "c3d4e5f6-a7b8-49c0-b1d2-e3f4a5b6c7d8",
       "transfer": {
         "id": "ad83f472-0505-4a4c-82c6-46686034a6d2",
         "status": "settled"
@@ -142,7 +142,7 @@ curl --request GET \
         "user_id": "a169451c-8525-4352-b8ca-070dd449a1a5",
         "amount": 1000,
         "platform": "paypal",
-        "idempotency_key": "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8",
+        "idempotency_key": "c3d4e5f6-a7b8-49c0-b1d2-e3f4a5b6c7d8",
         "fund": true,
         "tax_exempt": false,
         "metadata": {
@@ -152,7 +152,7 @@ curl --request GET \
     },
     {
       "user_id": "b269451c-9625-5452-c9db-171ee559b2b6",
-      "idempotency_key": "d4e5f6g7-h8i9-j0k1-l2m3-n4o5p6q7r8s9",
+      "idempotency_key": "d4e5f6a7-b8c9-40d1-a2e3-f4a5b6c7d8e9",
       "transfer": null,
       "metadata": null,
       "error_code": "no_such_resource",
@@ -162,7 +162,7 @@ curl --request GET \
         "amount": 2500,
         "platform": "ach",
         "account_id": "c369451c-a725-6552-d0ec-272ff669c3c7",
-        "idempotency_key": "d4e5f6g7-h8i9-j0k1-l2m3-n4o5p6q7r8s9",
+        "idempotency_key": "d4e5f6a7-b8c9-40d1-a2e3-f4a5b6c7d8e9",
         "fund": true,
         "tax_exempt": false
       }
@@ -185,7 +185,7 @@ Use the per-item `transfer.status` to reconcile payouts that succeeded (`settled
 ```sh
 curl --request GET \
   --url "https://api.senddotssandbox.com/api/v2/payout-batches?limit=10" \
-  --header 'Authorization: Basic <client_id:api_key>'
+  --header 'Authorization: Basic <base64(client_id:api_key)>'
 ```
 
 ## Best practices

--- a/docs/guides/flow-advanced-features.mdx
+++ b/docs/guides/flow-advanced-features.mdx
@@ -3,6 +3,8 @@ title: "Advanced Flow Features"
 # descriptions: 'Guide to implenting Dots Drop-in Components (flows) into your application.'
 ---
 
+<Note>Flows created with a `user_id` start in an authenticated state for 15 minutes. If the user comes back after that window, they must re-authenticate with an SMS verification code before continuing.</Note>
+
 ## Flow Messages
 
 Flows can send messages to your application using the `postMessage` API. Flows send two kinds of messages, the height of the iFrame and the status of the flow. To listen to these messages, you need to set up an event listener in your application.

--- a/docs/guides/flow-payouts.mdx
+++ b/docs/guides/flow-payouts.mdx
@@ -64,7 +64,7 @@ The following code block presents request and response examples of creating a Fl
 <CodeGroup>
   ```sh Request
     curl --request POST \
-      --url https://pls.senddotssandbox.com/api/v2/flows/ \
+      --url https://api.senddotssandbox.com/api/v2/flows/ \
       --header 'Authorization: Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
       --header 'Content-Type: application/json' \
       --data '{
@@ -107,7 +107,7 @@ After receiving the confirmation, you can use the [Retrieve Flow Information](/a
 <CodeGroup>
 ```sh Request
   curl --request GET \
-    --url https://pls.senddotssandbox.com/api/v2/flows/b3293101-35ef-451a-aad4-881da3697c2f \
+    --url https://api.senddotssandbox.com/api/v2/flows/b3293101-35ef-451a-aad4-881da3697c2f \
     --header 'Authorization: Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
 ```
 
@@ -142,7 +142,7 @@ The following code block presents request and response examples of creating a tr
 <CodeGroup>
 ```sh Request
 curl --request POST \
-  --url https://pls.senddotssandbox.com/api/v2/transfers \
+  --url https://api.senddotssandbox.com/api/v2/transfers \
   --header 'Authorization:  Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -195,7 +195,7 @@ The following code block presents request and response examples of creating a Fl
 <CodeGroup>
   ```sh Request
     curl --request POST \
-      --url https://pls.senddotssandbox.com/api/v2/flows/ \
+      --url https://api.senddotssandbox.com/api/v2/flows/ \
       --header 'Authorization: Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
       --header 'Content-Type: application/json' \
       --data '{
@@ -230,4 +230,3 @@ From the response, use the `link` to embed the payout process into an iframe wit
 ## What's Next?
 
 In addition to customizing the user journey, you can customize the Flow appearance. See [Flow Styles](guides/flow-styles) to learn how to change the Flows' appearance to match your branding. 
-

--- a/docs/guides/getting-started.mdx
+++ b/docs/guides/getting-started.mdx
@@ -29,7 +29,7 @@ After setting up your Dots account, the next step is to create an App. You can c
 2. Click **+ Create New** on the sidebar to create a new App. 
 3. Choose the **Organization**, provide an **App name**, and click **Create**.
 
-<Note>If you use the Sandbox environment, the new App will be created with a wallet balance of $1,000,000.00. This enables you to test the payout features provided by Dots.</Note>
+<Note>If you use the Sandbox environment, each new App starts with a pre-funded test balance. See [Environments](/overview/environments#sandbox-environment) for the current sandbox balance and top-up guidance.</Note>
 
 The new App will be available on the sidebar selector. The App ID will be available right below the selector.
 

--- a/docs/guides/payment.mdx
+++ b/docs/guides/payment.mdx
@@ -20,7 +20,7 @@ When a payment is created, a payment method is generated and saved to the [Payme
 Therefore, to setup future usage, create a [PaymentCustomer](/payment-customers/create-a-payment-customer) object on your server before creating the payment and save the `id` to your database. This will used in the following step. An alternative is to create a [Dots User](/users/overview) which will automatically back populates a payment customer on Dots end and use the `user.id` instead of `payment_customer.id`. 
 
 ```bash cURL
-https://pls.senddotssandbox.com/api/v2/payment-customers/ \
+https://api.senddotssandbox.com/api/v2/payment-customers/ \
 -X POST \
 -u "CLIENT_ID:API_KEY" \
 -H "Content-Type: application/json" \
@@ -49,7 +49,7 @@ Create a PaymentIntent on your server with an amount and currency. Always decide
 
 <CodeGroup>
 ```bash Single-use payment
-https://pls.senddotssandbox.com/api/v2/payment-intents/ \
+https://api.senddotssandbox.com/api/v2/payment-intents/ \
 -X POST \
 -u "CLIENT_ID:API_KEY" \
 -H "Content-Type: application/json" \
@@ -69,7 +69,7 @@ https://pls.senddotssandbox.com/api/v2/payment-intents/ \
 }
 ```
 ```bash Reusable payment
-https://pls.senddotssandbox.com/api/v2/payment-intents/ \
+https://api.senddotssandbox.com/api/v2/payment-intents/ \
 -X POST \
 -u "CLIENT_ID:API_KEY" \
 -H "Content-Type: application/json" \
@@ -390,7 +390,7 @@ When a customer completed the first payment, a payment method will be saved to t
 Follow [step 3](#3-create-a-payment-intent) to create a payment intent. Instead of passing in `customer_id` or `user_id`, pass in the `payment_method_id` and set `confirm` to `True`. This creates and confirm the payments immediately. 
 
 ```bash Off session payment
-https://pls.senddotssandbox.com/api/v2/payment-intents/ \
+https://api.senddotssandbox.com/api/v2/payment-intents/ \
 -X POST \
 -u "CLIENT_ID:API_KEY" \
 -H "Content-Type: application/json" \

--- a/docs/guides/payout-links.mdx
+++ b/docs/guides/payout-links.mdx
@@ -47,7 +47,7 @@ You can create a Payout Link using the Dashboard or the API. Below you will find
       <CodeGroup>
       ```sh Request
       curl --request POST \
-      --url https://pls.senddotssandbox.com/api/v2/payout-links \
+      --url https://api.senddotssandbox.com/api/v2/payout-links \
       --header 'Authorization: Basic <token>' \
       --header 'Content-Type: application/json' \
       --data '{

--- a/docs/guides/white-labeled-payouts.mdx
+++ b/docs/guides/white-labeled-payouts.mdx
@@ -135,6 +135,8 @@ From the response, use the `link` to embed the Flow into an iframe within your a
 
 To start the Flow, Dots will send a verification code to the user's phone to confirm their identity. Once verified, all available payout methods will be displayed. The user can then select their preferred payout method and provide the necessary information. At the end of the process, there is an option to set this as the default payment method, which is selected by default. If the user has a default payout method in their account, funds can be transferred automatically using this method.
 
+Flows created with a `user_id` stay authenticated for 15 minutes. If the user takes longer, they must re-authenticate with an SMS verification code before continuing.
+
 </Note>
 
 After the user has set a default payout method, you can proceed to the next step. 
@@ -148,7 +150,9 @@ You can create the payout using one of two methods:
 
 ### Two Steps
 
-For a two-step process, first use the [Create a Transfer](/apireference/transfers/create-a-transfer) endpoint to transfer funds from your app wallet to the user's wallet. You need to provide the `amount` and the `user_id` you received in [Step 1](#1-create-a-user). Request and response examples: 
+For a two-step process, first use the [Create a Transfer](/apireference/transfers/create-a-transfer) endpoint to transfer funds from your app wallet to the user's wallet. You need to provide the `amount` and the `user_id` you received in [Step 1](#1-create-a-user). Request and response examples:
+
+<Note>Transfer amounts use a signed convention: use a negative `amount` to move funds from your App wallet to the user, and a positive `amount` to debit funds from the user.</Note>
 
 <CodeGroup>
   ```sh Request

--- a/docs/guides/white-labeled-payouts.mdx
+++ b/docs/guides/white-labeled-payouts.mdx
@@ -38,7 +38,7 @@ Request and response examples:
 <CodeGroup>
 ```sh Request
 curl --request POST \
-  --url https://pls.senddotssandbox.com/api/v2/users \
+  --url https://api.senddotssandbox.com/api/v2/users \
   --header 'Authorization: Basic cGtfZGV2X3lpYXF0aXkwOGdIb3gzR3pvUEo2RlFsaURkSDRnOnNrX2Rldl9nUDBHQjZCd1FmZmt3S2FEVkh0UmdTd0NPT2RNVA==' \
   --header 'Content-Type: application/json' \
   --data '{
@@ -102,7 +102,7 @@ To add a default payout method to the user's account, use the [Create a Flow](/a
 <CodeGroup>
   ```sh Request
     curl --request POST \
-      --url https://pls.senddotssandbox.com/api/v2/flows/ \
+      --url https://api.senddotssandbox.com/api/v2/flows/ \
       --header 'Authorization: Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
       --header 'Content-Type: application/json' \
       --data '{
@@ -157,7 +157,7 @@ For a two-step process, first use the [Create a Transfer](/apireference/transfer
 <CodeGroup>
   ```sh Request
     curl --request POST \
-      --url https://api.dots.dev/api/v2/transfers  \
+      --url https://api.senddotssandbox.com/api/v2/transfers  \
       --header 'Authorization: Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
       --header 'Content-Type: application/json' \
         --data '{
@@ -199,7 +199,7 @@ After transferring the funds to the user's wallet, you can create the payout usi
 <CodeGroup>
   ```sh Request
       curl --request POST \
-        --url https://api.dots.dev/api/v2/payouts \
+        --url https://api.senddotssandbox.com/api/v2/payouts \
         --header 'Authorization: Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
         --header 'Content-Type: application/json' \
         --data '{
@@ -251,7 +251,7 @@ Request and response examples:
 <CodeGroup>
   ```sh Request
       curl --request POST \
-        --url https://api.dots.dev/api/v2/payouts \
+        --url https://api.senddotssandbox.com/api/v2/payouts \
         --header 'Authorization: Basic cGtfZGV2X0g3V0tFOXlTRGhqeW91dFZBNEk3RkxhVkUzaWg1OnNrX2Rldl9lekFPNXA0WUNJeld6RWgwam5ubHFrODRkQ3ZFOQ==' \
         --header 'Content-Type: application/json' \
         --data '{

--- a/docs/overview/authentication.mdx
+++ b/docs/overview/authentication.mdx
@@ -81,7 +81,7 @@ curl --request POST \
 ```
 
 ```curl Send Payout
-https://pls.senddotssandbox.com/api/v2/payouts/send-payout \
+https://api.senddotssandbox.com/api/v2/payouts/send-payout \
 -X POST \
 -u "CLIENT_ID: <organization_key>" \
 -H "Content-Type: application/json" \
@@ -105,4 +105,4 @@ To access your organization keys, you can email info@dots.dev, or you can access
 ![Organization keys](../images/organization-keys.png)
 </Frame>
 
-If you're using the organization key to authenticate actions on an App's behalf, you need to include the App's ID with the `Api-App-Id` header in the request. The ID can be retrieved using the [List All Apps](/apireference/users/list-all-users) endpoint or the [Dashboard](https://dashboard.dots.dev/).
+If you're using the organization key to authenticate actions on an App's behalf, you need to include the App's ID with the `Api-App-Id` header in the request. The ID can be retrieved using the [List All Apps](/apireference/apps/list-all-apps) endpoint or the [Dashboard](https://dashboard.dots.dev/).

--- a/docs/overview/authentication.mdx
+++ b/docs/overview/authentication.mdx
@@ -1,5 +1,5 @@
 ---
-title: "API Authentication"
+title: "Authentication"
 # description: "How to authenticate requests to the API."
 ---
 

--- a/docs/overview/environments.mdx
+++ b/docs/overview/environments.mdx
@@ -1,6 +1,6 @@
 ---
 sidebarTitle: "Environments"
-title: "Dots API Environments"
+title: "Environments"
 ---
 
 The Dots API provides two environments for integration: 
@@ -60,5 +60,4 @@ To request access to the Production environment, contact us at info@dots.dev or 
 1. Log in to the Dots Dashboard and toggle off the **View Sandbox Environment** in the upper left corner. A **PRODUCTION MODE** badge appears on the top of the page.
 2. You need to set up a new application and generate new API keys.
 3. If you're using Dots API, you must update the base API URL to https://api.dots.dev/api/.
-
 

--- a/docs/overview/environments.mdx
+++ b/docs/overview/environments.mdx
@@ -7,7 +7,7 @@ The Dots API provides two environments for integration:
 
 | Environment | Description | Base URL |
 |-------------|-----------|------------------------------------------|
-| [Sandbox](#sandbox-environment)|Allows you to develop and test the integration without affecting live funds.       | `https://pls.senddotssandbox.com/api`  |
+| [Sandbox](#sandbox-environment)|Allows you to develop and test the integration without affecting live funds.       | `https://api.senddotssandbox.com/api`  |
 | [Production](#production-environment)| It's used for live transactions after successfully testing the integration.   | `https://api.dots.dev/api`  |
 
 <Note>
@@ -32,7 +32,7 @@ To use the Sandbox environment, you should follow the steps presented below:
 
 1. Log in to the Dots Dashboard and toggle the **View Sandbox Environment** in the upper left corner. A **SANDBOX MODE** badge appears on the top of the page.
 2. Set up an application and generate API keys.
-3. Use https://pls.senddotssandbox.com/api for Sandbox API requests.
+3. Use https://api.senddotssandbox.com/api for Sandbox API requests.
 
 <Frame>
   <img src="/images/sandbox-setup.gif" />
@@ -60,4 +60,3 @@ To request access to the Production environment, contact us at info@dots.dev or 
 1. Log in to the Dots Dashboard and toggle off the **View Sandbox Environment** in the upper left corner. A **PRODUCTION MODE** badge appears on the top of the page.
 2. You need to set up a new application and generate new API keys.
 3. If you're using Dots API, you must update the base API URL to https://api.dots.dev/api/.
-

--- a/docs/overview/introduction.mdx
+++ b/docs/overview/introduction.mdx
@@ -74,7 +74,7 @@ Next, you'll choose one of the three Dots integration options available. If you 
     title='Dots Concepts'
     icon='square-1'
     color='#0285c7'
-    href='/overview/dots-concepts'
+    href='/overview/concepts'
   >
     Take a deeper dive into the concepts related to the Dots solution.
   </Card>
@@ -93,6 +93,14 @@ Next, you'll choose one of the three Dots integration options available. If you 
     href='/apireference'
   >
     Explore the available functionalities Dots API provides to you.
+  </Card>
+  <Card
+    title='Documentation Index'
+    icon='square-terminal'
+    color='#7c3aed'
+    href='/llms.txt'
+  >
+    Browse the AI-readable documentation index for the current docs site.
   </Card>
   <Card
     title='Supported Countries'

--- a/docs/references/webhooks.mdx
+++ b/docs/references/webhooks.mdx
@@ -297,7 +297,7 @@ When creating an endpoint on Svix, you can subscribe to a wide list of events to
 
   </Accordion>
 
-  <Accordion title="user.updated.ide_verified">
+  <Accordion title="user.updated.id_verified">
 
   Triggered when a user's ID is verified.
 

--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -301,11 +301,13 @@ paths:
                       description: "Type of entity filling out the W-9, `business` or `individual`."
                     business_name:
                       type: string
-                      description: Legal bussiness name. Required if `entity_type` is `business`.
+                      description: Legal business name. Required if `entity_type` is `business`.
                     first_name:
                       type: string
+                      description: Required if `entity_type` is `individual`.
                     last_name:
                       type: string
+                      description: Required if `entity_type` is `individual`.
                     date_of_birth:
                       type: string
                       format: date
@@ -345,9 +347,25 @@ paths:
                           description: Postal code or Zip code.
                   required:
                     - entity_type
-                    - date_of_birth
                     - tin
                     - address
+                  allOf:
+                    - if:
+                        properties:
+                          entity_type:
+                            const: individual
+                      then:
+                        required:
+                          - first_name
+                          - last_name
+                          - date_of_birth
+                    - if:
+                        properties:
+                          entity_type:
+                            const: business
+                      then:
+                        required:
+                          - business_name
                 w8ben:
                   type: object
                   description: W8-BEN form for foreign payees.
@@ -750,6 +768,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/transfer"
                 description: The `transfer` object.
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/transfer"
+                description: The `transfer` object.
       requestBody:
         content:
           application/json:
@@ -758,7 +783,7 @@ paths:
               properties:
                 amount:
                   type: integer
-                  description: The amount in cents to transfer. Negative amount transfers money from the `app` to the `user`.
+                  description: The amount in cents to transfer. Use a negative amount to send money from the `app` to the `user`, and a positive amount to debit money from the `user`.
                 user_id:
                   type: string
                   format: uuid
@@ -793,7 +818,7 @@ paths:
                   amount: 1000
                   user_id: a169451c-8525-4352-b8ca-070dd449a1a5
         description: ""
-      description: Create a transfer.
+      description: Create a transfer. Use a negative `amount` to send funds from your App wallet to the user, and a positive `amount` to debit the user.
       tags:
         - transfers
     parameters: []
@@ -931,7 +956,7 @@ paths:
                 user_id:
                   type: string
                   format: uuid
-                  description: The user's id. If the user's ID is provided, the flow will be created in the authenticated state with a 15 minute expiration time unless the `require_auth` option is set to `true`.
+                  description: The user's id. If the user's ID is provided, the flow is created in an authenticated state for 15 minutes unless `require_auth` is set to `true`. After that window, the user must re-authenticate with an SMS verification code before continuing.
                 hide_go_to_dashboard_on_complete:
                   type: boolean
                   description: Hide the "Go to dashboard" button on the flow UI. Defaults to `false`.
@@ -1196,6 +1221,13 @@ paths:
       summary: Create a Payout
       operationId: create-payout
       responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/transfer"
+                description: The `transfer` object.
         "201":
           description: Created
           content:
@@ -1459,6 +1491,13 @@ paths:
       summary: Send a Payout
       operationId: send-payout
       responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/payout-link"
+                description: The `payout-link` object.
         "201":
           description: Created
           content:
@@ -3838,6 +3877,13 @@ paths:
               schema:
                 $ref: "#/components/schemas/refund"
                 description: The `refund` object.
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/refund"
+                description: The `refund` object.
       description: Create a Refund
       requestBody:
         content:
@@ -3862,7 +3908,10 @@ paths:
                     - expired_uncaptured_charge
                     - partial_capture
                 metadata:
-                  type: boolean
+                  type:
+                    - string
+                    - object
+                    - "null"
                   description: Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
               required:
                 - amount

--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -12,6 +12,8 @@ info:
     name: MIT
     url: "https://opensource.org/license/mit/"
 servers:
+  - url: "https://api.senddotssandbox.com/api"
+    description: Sandbox
   - url: "https://api.dots.dev/api"
     description: Production
 tags:
@@ -1288,7 +1290,7 @@ paths:
                     - user_id: "a169451c-8525-4352-b8ca-070dd449a1a5"
                       amount: 1000
                       platform: "paypal"
-                      idempotency_key: "b2c3d4e5-f6g7-h8i9-j0k1-l2m3n4o5p6q7"
+                      idempotency_key: "b2c3d4e5-f6a7-48i9-a0k1-l2m3n4o5p6q7"
                       fund: true
                       tax_exempt: false
                       metadata:
@@ -1297,7 +1299,7 @@ paths:
                       amount: 2500
                       platform: "ach"
                       account_id: "c369451c-a725-6552-d0ec-272ff669c3c7"
-                      idempotency_key: "c3d4e5f6-g7h8-i9j0-k1l2-m3n4o5p6q7r8"
+                      idempotency_key: "c3d4e5f6-a7b8-49c0-b1d2-e3f4a5b6c7d8"
                       fund: true
                       tax_exempt: false
                   metadata:


### PR DESCRIPTION
## Summary
- fix the audited documentation correctness issues in the OpenAPI spec, including refund metadata typing, W-9 conditional requirements, clearer transfer semantics, flow re-authentication guidance, and webhook event naming
- resolve docs navigation and indexing drift by adding an API reference landing page, fixing broken overview links, adding redirects, and setting the canonical docs domain for generated SEO and AI index artifacts
- remove duplicated or conflicting guide copy by pointing sandbox balance guidance back to the environments page and by surfacing flow expiry and transfer-sign behavior where those workflows are documented

## Validation
- ran `npx mintlify@latest validate` in `docs/`

---
*Created with [Open-Inspect](https://open-inspect-web-snippets.usedots.workers.dev/session/ed3d7c4e56137db62a7787f215e4fbce)*