### PR TITLE
Document multitenancy KYB flow

### DIFF
--- a/docs/apps/create-kyb-flow.mdx
+++ b/docs/apps/create-kyb-flow.mdx
@@ -1,0 +1,5 @@
+---
+title: 'Create an App KYB Flow'
+description: "Create a hosted KYB flow for an app in a multi-tenant organization"
+openapi: 'POST /v2/apps/{app_id}/kyb-flow'
+---

--- a/docs/apps/refresh-compliance-flow.mdx
+++ b/docs/apps/refresh-compliance-flow.mdx
@@ -1,5 +1,0 @@
----
-title: 'Refresh App Compliance Flow'
-description: "Get or refresh an app's KYB compliance flow"
-openapi: 'POST /v2/apps/{app_id}/compliance-flow'
----

--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -3175,7 +3175,7 @@ paths:
                   description: Idempotency key in UUID format.
               required:
                 - amount
-  "/v2/apps/{app_id}/compliance-flow":
+  "/v2/apps/{app_id}/kyb-flow":
     parameters:
       - schema:
           type: string
@@ -3184,23 +3184,44 @@ paths:
         required: true
         description: The ID of the App.
     post:
-      summary: Refresh compliance flow
-      operationId: post-app-compliance-flow
+      summary: Create a KYB flow
+      operationId: post-app-kyb-flow
       responses:
-        "200":
-          description: OK
+        "201":
+          description: KYB flow created
           content:
             application/json:
               schema:
-                type: string
+                type: object
+                required:
+                  - url
+                  - expires_at
+                  - status
+                properties:
+                  url:
+                    type: string
+                    format: uri
+                    description: The hosted KYB flow URL to share with the app's owner.
+                  expires_at:
+                    type: string
+                    format: date-time
+                    description: The time when the hosted KYB flow URL expires.
+                  status:
+                    type: string
+                    enum:
+                      - pending
+                    description: The initial status of the KYB flow.
       tags:
         - apps
-      description: Refresh the app's KYB compliance flow. Returns a URL
-        that can be shared or embedded to allow the app's owners to
-        submit mandatory onboarding information about their business.
+      description: Create a hosted KYB flow for an app in a multi-tenant
+        organization. Share the returned URL with the app's owner so they can
+        submit the business and beneficial-owner information required for
+        verification.
 
-        The flow URL will expire after 72 hours. Refreshing the flow
-        will also expire the old URL.
+        The URL expires after 72 hours. Calling this endpoint again creates a
+        new URL and immediately invalidates the previous one. The endpoint is
+        only available for apps configured for individual business verification
+        that have not already reached a terminal or review state.
   "/v2/apps/{app_id}/change_settings":
     parameters:
       - schema:


### PR DESCRIPTION
## What changed

- document `POST /v2/apps/{app_id}/kyb-flow` for multi-tenant app verification
- describe the hosted URL, 72-hour expiration, pending status, and URL rotation behavior
- remove the legacy `/compliance-flow` API reference and its MDX page

## Why

Multi-tenant integrations now use the dedicated hosted KYB flow route. The API reference should expose the new response contract and no longer direct integrators to the old flow.

## Validation

- parsed `docs/v2.yaml` successfully
- confirmed the new KYB route is present and the legacy compliance-flow route is absent
- ran `git diff --check`
