### PR TITLE
Update create user v2 documentation

### DIFF
--- a/docs/users/create-a-user.mdx
+++ b/docs/users/create-a-user.mdx
@@ -13,7 +13,7 @@ Create and verify a user to your `application`.
 
 ---
 
-## Creating a Users
+## Creating a User
 
 Creating users happens through the [/v2/users](/apireference/v2/users/create-user) endpoint. Once hit, a dots user will be created if one does not exist based on phone number. This user must then be verified through a one-time code sent over text-message. This code can be requested through the [/v2/users/\{user_id\}/send-verification-token](/apireference/v2/users/send-verification-token) endpoint and then verified through the [/v2/users/\{user_id\}/verify](/apireference/v2/users/verify-user) endpoint.
 
@@ -34,11 +34,13 @@ Make a `POST` request to the [/v2/users](/apireference/v2/users/create-user) end
         "phone_number": "1234567890",
         "first_name": "Bob",
         "last_name": "Loblaw",
-        "username": <Optional>
+        "username": "bob-loblaw"
       }'
 
-> response = {
+> HTTP/1.1 201 Created
+> {
     "id": "143c7e1c-2295-42c0-9fc9-23756ac26250",
+    "country": "US",
     "first_name": "Bob",
     "last_name": "Loblaw",
     "email": "test@senddots.com",
@@ -46,19 +48,10 @@ Make a `POST` request to the [/v2/users](/apireference/v2/users/create-user) end
       "country_code": "1",
       "phone_number": "1234567890"
     },
-    "wallet": {
-      "amount": 0,
-      "withdrawable_balance": 0,
-      "credit_balance": 0
-    },
-    "compliance": {
-      "tax_id_collected": false,
-      "address_collected": false,
-      "date_of_birth_collected": false,
-      "1099_collected": false,
-      "w8_ben_collected": false,
-      "flagged": false
-    }
+    "metadata": {},
+    "verified": false,
+    "status": "unverified",
+    "payout_options_exclude_list": []
   }
 
 ```
@@ -67,16 +60,18 @@ Make a `POST` request to the [/v2/users](/apireference/v2/users/create-user) end
 
 ##### Parameters
 
-| Name         | Type               | Required | Description                                                                                                  |
-| ------------ | ------------------ | -------- | ------------------------------------------------------------------------------------------------------------ |
-| email        | string             | ✔️       | User's email address                                                                                         |
-| country_code | string             | ✔️       | User's phone number country code without the plus sign ('1' for the US)                                      |
-| phone_number | string             | ✔️       | User's phone number as a string containing only digits                                                       |
-| first_name   | string             | ✔️       | User's first name as a string                                                                                |
-| last_name    | string             | ✔️       | User's last name as a string                                                                                 |
-| username     | string             |          | User's username on your platform. If the username is taken or left blank a random username will be generated |
-| metadata     | string/object/null |          | Optional metadata to be stored with the user                                                                 |
-| payout_options_exclude_list | array |          | List of payout methods to hide from this user (e.g. `["venmo", "paypal"]`).                                  |
+| Name                          | Type               | Required | Description |
+| ----------------------------- | ------------------ | -------- | ----------- |
+| email                         | string             | ✔️       | A valid email address. |
+| country_code                  | string             | ✔️       | The phone country code without the plus sign, containing 1–3 digits (for example, `"1"` for the US). |
+| phone_number                  | string             | ✔️       | The phone number, containing 1–20 digits. |
+| first_name                    | string             | ✔️       | The user's first name, containing 1–50 characters. |
+| last_name                     | string             | ✔️       | The user's last name, containing 1–50 characters. |
+| username                      | string             |          | A username containing 1–50 characters. If omitted, a random username is generated. |
+| date_of_birth                 | string             |          | The user's date of birth in `YYYY-MM-DD` format. |
+| 1099_adjustment               | object             |          | Current-year income paid outside Dots. Use `{"year": 2026, "form": "1099-NEC", "amount": 10000}` for 1099-NEC, or provide all 12 `monthly_amounts` and an optional `transaction_count` for 1099-K. The form must match the application's configured filing type. Amounts are in cents. |
+| metadata                      | string/object/null |          | Optional metadata to store with the user. |
+| payout_options_exclude_list   | array              |          | A unique list of payout methods to hide from this user (for example, `["venmo", "paypal"]`). |
 
 ## Verifying the created User
 

--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -99,8 +99,8 @@ paths:
       summary: Create a User
       operationId: create-user
       responses:
-        "200":
-          description: OK
+        "201":
+          description: Created
           content:
             application/json:
               schema:
@@ -114,9 +114,13 @@ paths:
               properties:
                 first_name:
                   type: string
+                  minLength: 1
+                  maxLength: 50
                   description: The user's first name.
                 last_name:
                   type: string
+                  minLength: 1
+                  maxLength: 50
                   description: The user's last name.
                 email:
                   type: string
@@ -124,9 +128,11 @@ paths:
                   description: The user's email address.
                 country_code:
                   type: string
+                  pattern: "^[0-9]{1,3}$"
                   description: The user's phone number country code. e.g. "1"
                 phone_number:
                   type: string
+                  pattern: "^[0-9]{1,20}$"
                   description: The user's phone number. e.g. "4157223331".
                 username:
                   type: string
@@ -137,10 +143,8 @@ paths:
                   type: string
                   format: date
                   description: User's date of birth.
-                1099_adjustment_2024:
-                  type: integer
-                  minimum: 1
-                  description: Income paid outside of the Dots platform in 2024.
+                1099_adjustment:
+                  $ref: "#/components/schemas/1099-adjustment"
                 metadata:
                   type:
                     - string
@@ -249,10 +253,8 @@ paths:
                   type: string
                   format: date
                   description: User's date of birth.
-                1099_adjustment_2024:
-                  type: integer
-                  minimum: 1
-                  description: Income paid outside of the Dots platform in 2024.
+                1099_adjustment:
+                  $ref: "#/components/schemas/1099-adjustment"
                 metadata:
                   description: Arbitrary metadata
                 payout_options_exclude_list:
@@ -3588,6 +3590,89 @@ components:
         - airtm
         - payoneer
         - crypto
+    1099-adjustment:
+      description: >-
+        Income paid outside of the Dots platform in the current calendar year.
+        The form must match the application's configured 1099 filing type.
+      oneOf:
+        - title: 1099-NEC adjustment
+          type: object
+          additionalProperties: false
+          properties:
+            year:
+              type: integer
+              description: The current calendar year.
+            form:
+              type: string
+              const: 1099-NEC
+            amount:
+              type: integer
+              minimum: 1
+              description: The adjustment amount in cents.
+          required:
+            - year
+            - form
+            - amount
+        - title: 1099-K adjustment
+          type: object
+          additionalProperties: false
+          properties:
+            year:
+              type: integer
+              description: The current calendar year.
+            form:
+              type: string
+              const: 1099-K
+            monthly_amounts:
+              type: object
+              additionalProperties: false
+              description: Adjustment amounts in cents for every month of the year.
+              properties:
+                january:
+                  type: integer
+                february:
+                  type: integer
+                march:
+                  type: integer
+                april:
+                  type: integer
+                may:
+                  type: integer
+                june:
+                  type: integer
+                july:
+                  type: integer
+                august:
+                  type: integer
+                september:
+                  type: integer
+                october:
+                  type: integer
+                november:
+                  type: integer
+                december:
+                  type: integer
+              required:
+                - january
+                - february
+                - march
+                - april
+                - may
+                - june
+                - july
+                - august
+                - september
+                - october
+                - november
+                - december
+            transaction_count:
+              type: integer
+              minimum: 1
+              description: Transactions paid outside of Dots during the year.
+          required:
+            - year
+            - form
+            - monthly_amounts
     flow:
       type: object
       properties:

--- a/docs/v2.yaml
+++ b/docs/v2.yaml
@@ -4166,6 +4166,13 @@ components:
           items:
             $ref: "#/components/schemas/rail"
           description: Payout rails hidden from this user. Stacks with app-level exclusions.
+        1099_adjustment:
+          $ref: "#/components/schemas/1099-adjustment"
+          description: >-
+            Current-year 1099 adjustment for the user, if one has been set.
+            Only returned by the retrieve-a-user endpoint (`GET /v2/users/{user_id}`)
+            when the application's configured filing type has a matching adjustment;
+            omitted otherwise and never included in list responses.
     wallet:
       type: object
       properties:


### PR DESCRIPTION
## Summary

- document the `POST /v2/users` success response as `201 Created`
- replace the legacy `1099_adjustment_2024` field with the current-year `1099_adjustment` schemas for 1099-NEC and 1099-K
- correct the unverified-user response example and document request validation constraints

## Why

The create-user v2 documentation had drifted from the backend contract: it listed a `200` response, described the fixed 2024 adjustment field, and showed wallet and compliance data that is not returned for a newly created unverified user.

## Impact

Developers integrating with create-user v2 will see the current request fields, validation rules, status code, and response shape.

## Checks

- parsed `docs/v2.yaml` and asserted the create-user response, validation, and adjustment schemas
- ran `git diff --check`
